### PR TITLE
Get integration tests running.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install Node.js and then:
 ```sh
 $ git clone git://github.com/cloudspace/angular.crunchinator.com
 $ cd angular.crunchinator.com
-$ sudo npm -g install grunt-cli karma bower
+$ sudo npm -g install grunt-cli karma bower protractor
 $ npm install
 $ bower install
 $ npm install grunt --save-dev

--- a/integration.js
+++ b/integration.js
@@ -1,0 +1,5 @@
+exports.config = {
+  // Spec patterns are relative to the current working directly when
+  // protractor is called.
+  specs: ['integration/**/*.js']
+};

--- a/integration/example.js
+++ b/integration/example.js
@@ -1,0 +1,11 @@
+describe('angularjs homepage', function() {
+  it('should greet the named user', function() {
+    browser.get('http://www.angularjs.org');
+
+    element(by.model('yourName')).sendKeys('Julie');
+
+    var greeting = element(by.binding('yourName'));
+
+    expect(greeting.getText()).toEqual('Hello Julie!');
+  });
+});


### PR DESCRIPTION
Must install protractor with `npm install -g protractor`. Then run
`protractor integration.js`, which will run all integration tests in
integration/ directory.

Protractor uses Seleniums WebDriverJS syntax.
https://code.google.com/p/selenium/wiki/WebDriverJs
