### PR TITLE
Selected round names aren't being displayed after application of other filters

### DIFF
--- a/app/scripts/services/componentData.js
+++ b/app/scripts/services/componentData.js
@@ -7,15 +7,12 @@ angular.module('crunchinatorApp.services').service('ComponentData', function() {
      * @param {array} [companies] A filtered list of companies to construct a list of displayed round codes
      * @return {array} A list of round codes
      */
-    this.roundCodeListData = _.memoize(function(rounds) {
+    this.roundCodeListData = _.memoize(function(rounds, roundHash) {
         if(typeof rounds === 'undefined') { return []; }
 
         var codeNames = _.unique(_.pluck(rounds, 'round_code'));
         var sortedRoundCodes = _.sortBy(_.map(codeNames, function(roundCode){
-            return {
-                name: roundCode.length > 1 ? roundCode : 'Series ' + roundCode,
-                id: roundCode
-            };
+            return roundHash[roundCode];
         }), function(round){ return round.name; });
 
         return sortedRoundCodes;

--- a/app/scripts/services/fundingRound.js
+++ b/app/scripts/services/fundingRound.js
@@ -64,6 +64,7 @@ angular.module('crunchinatorApp.models').service('FundingRound', function(Model,
     FundingRound.prototype.setupDimensions = function() {
         var crossFundingRounds = crossfilter(this.all);
         var parse = this.format.parse;
+        var self = this;
 
         this.dimensions = {
             byCompany: crossFundingRounds.dimension(function(round) { return round.company; }),
@@ -82,6 +83,13 @@ angular.module('crunchinatorApp.models').service('FundingRound', function(Model,
         this.maxFundingValue = parseInt(_.max(allFundingValues, function(n){ return parseInt(n); }));
 
         this.fundingSeries = _.unique(_.pluck(this.all, 'round_code'));
+        this.roundHash = {};
+        _.each(this.fundingSeries, function(roundCode){
+            self.roundHash[roundCode] = {
+                name: roundCode.length > 1 ? roundCode : 'Series ' + roundCode,
+                id: roundCode
+            };
+        });
     };
 
     /**

--- a/app/views/main.tpl.html
+++ b/app/views/main.tpl.html
@@ -108,7 +108,7 @@
         <div>
             <div list-select
                 chart-title="Funding: Round Name"
-                items="ComponentData.roundCodeListData(fundingRounds.dataForRoundName)"
+                items="ComponentData.roundCodeListData(fundingRounds.dataForRoundName, fundingRounds.roundHash)"
                 selected="roundCodes"
                 total="fundingRounds.fundingSeries.length"
             ></div>


### PR DESCRIPTION
@hkal https://www.pivotaltracker.com/story/show/66684440

Rewrote the component data function so that the items displayed in the list select weren't being recreated each time. They're created once in the FundingRound model and then referenced by name later so that the intersection to generate the displayed selected list works in the list display directive.
