### PR TITLE
Smoother UI interactions. No longer painful to use

### DIFF
--- a/app/scripts/controllers/crunchinator.js
+++ b/app/scripts/controllers/crunchinator.js
@@ -20,6 +20,8 @@ angular.module('crunchinatorApp.controllers')
     function CrunchinatorCtrl($scope, $location, $q, Company, Category, Investor, FundingRound, ComponentData) {
         $scope.loading = true;
 
+        ComponentData.updateDataSets();
+
         //Create the initial empty filter data for every filter
         $scope.filterData = {
             categoryIds: [],
@@ -76,7 +78,7 @@ angular.module('crunchinatorApp.controllers')
                         Model.setupDimensions();
                         Model.runFilters($scope.filterData);
                     });
-
+                    ComponentData.updateDataSets();
                     $scope.loading = false;
                 }
             });
@@ -99,7 +101,7 @@ angular.module('crunchinatorApp.controllers')
                         Category.runFilters($scope.filterData);
                         Investor.runFilters($scope.filterData);
                         FundingRound.runFilters($scope.filterData);
-
+                        ComponentData.updateDataSets();
                         deferred.resolve('Finished filters');
                     });
                 }, 250);

--- a/app/scripts/services/componentData.js
+++ b/app/scripts/services/componentData.js
@@ -1,6 +1,31 @@
 'use strict';
 
-angular.module('crunchinatorApp.services').service('ComponentData', function() {
+angular.module('crunchinatorApp.services').service('ComponentData', function(Company, Investor, Category, FundingRound) {
+    this.dataSets ={};
+    this.updateDataSets = function() {
+        var data = this.dataSets;
+        //Run each data function
+        data.roundCodeListData = this.roundCodeListData(FundingRound.dataForRoundName);
+        // data.categoryListData = this.categoryListData();
+        // data.investorListData = this.investorListData();
+        data.totalFunding = this.totalFunding(Company.dataForTotalFunding, Company.maxCompanyValue);
+        data.fundingRoundCount = this.fundingRoundCount(FundingRound.dataForInvestments, '1/2000');
+        data.acquiredOnCount = this.acquiredOnCount(Company.dataForAcquiredOnAreaChart, '1/2006');
+        data.acquiredValueCount = this.acquiredValueCount(Company.dataForAcquiredValue, Company.maxAcquiredValue);
+        data.foundedOnCount = this.foundedOnCount(Company.dataForFoundedOnAreaChart, '1992');
+        data.fundingPerRound = this.fundingPerRound(FundingRound.dataForFundingAmount, FundingRound.maxFundingValue);
+        data.mostRecentFundingRound = this.mostRecentFundingRound(Company.dataForMostRecentRaisedAmount, Company.maxRecentFundingValue);
+        data.companyStatusData = this.companyStatusData(Company.dataForCompanyStatus);
+        data.companyStateData = this.companyStateData(Company.dataForLocationMap);
+        data.ipoValueData = this.ipoValueData(Company.dataForIPOValue, Company.maxIPOValue);
+        data.ipoDateData = this.ipoDateData(Company.dataForIPODate, '1992');
+    };
+
+    var idListMemoFunction = function(items) {
+        var current_hash = _.pluck(items, 'id').join('|');
+        return current_hash;
+    };
+
     /**
      * Constructs data necessary for the round code list display
      *
@@ -20,10 +45,7 @@ angular.module('crunchinatorApp.services').service('ComponentData', function() {
 
         return sortedRoundCodes;
 
-    }, function(rounds) {
-        var current_hash = _.pluck(rounds, 'id').join('|');
-        return current_hash;
-    });
+    }, idListMemoFunction);
 
     /**
      * Constructs data necessary for the category list display
@@ -97,10 +119,7 @@ angular.module('crunchinatorApp.services').service('ComponentData', function() {
             }
         }
         return ranges;
-    }, function(companies) {
-        var current_hash = _.pluck(companies, 'id').join('|');
-        return current_hash;
-    });
+    }, idListMemoFunction);
 
     /**
      * Constructs data necessary for the Funding: Any Round area chart
@@ -136,10 +155,7 @@ angular.module('crunchinatorApp.services').service('ComponentData', function() {
             });
             return o;
         }, []);
-    }, function(round) {
-        var current_hash = _.pluck(round, 'id').join('|');
-        return current_hash;
-    });
+    }, idListMemoFunction);
 
     /**
      * Constructs data necessary for the Acquisition Date area chart
@@ -175,10 +191,7 @@ angular.module('crunchinatorApp.services').service('ComponentData', function() {
             });
             return o;
         }, []);
-    }, function(companies) {
-        var current_hash = _.pluck(companies, 'id').join('|');
-        return current_hash;
-    });
+    }, idListMemoFunction);
 
     /**
      * Constructs data necessary for the acquired value bar graph
@@ -209,10 +222,7 @@ angular.module('crunchinatorApp.services').service('ComponentData', function() {
             }
         }
         return ranges;
-    }, function(companies) {
-        var current_hash = _.pluck(companies, 'id').join('|');
-        return current_hash;
-    });
+    }, idListMemoFunction);
 
     /**
      * Constructs data necessary for the Date Founded area chart
@@ -250,10 +260,7 @@ angular.module('crunchinatorApp.services').service('ComponentData', function() {
             });
             return o;
         }, []);
-    }, function(companies) {
-        var current_hash = _.pluck(companies, 'id').join('|');
-        return current_hash;
-    });
+    }, idListMemoFunction);
 
     /**
      * Constructs data necessary for the Funding: Any Round bar chart
@@ -285,10 +292,7 @@ angular.module('crunchinatorApp.services').service('ComponentData', function() {
             }
         }
         return ranges;
-    }, function(rounds) {
-        var current_hash = _.pluck(rounds, 'id').join('|');
-        return current_hash;
-    });
+    }, idListMemoFunction);
 
     /**
      * Constructs data necessary for the Funding: Most Recent Round bar chart
@@ -321,10 +325,7 @@ angular.module('crunchinatorApp.services').service('ComponentData', function() {
             }
         }
         return ranges;
-    }, function(companies) {
-        var current_hash = _.pluck(companies, 'id').join('|');
-        return current_hash;
-    });
+    }, idListMemoFunction);
 
     /**
      * Constructs data necessary for the Company Status pie chart
@@ -348,19 +349,13 @@ angular.module('crunchinatorApp.services').service('ComponentData', function() {
         });
 
         return results;
-    }, function(companies) {
-        var current_hash = _.pluck(companies, 'id').join('|');
-        return current_hash;
-    });
+    }, idListMemoFunction);
 
     this.companyStateData = _.memoize(function(companies) {
         var state_grouping = _.countBy(companies, function(company) { return company.state_code; });
 
         return state_grouping;
-    }, function(companies) {
-        var current_hash = _.pluck(companies, 'id').join('|');
-        return current_hash;
-    });
+    }, idListMemoFunction);
 
     /**
      * Constructs data necessary for the IPO Value bar graph
@@ -390,10 +385,7 @@ angular.module('crunchinatorApp.services').service('ComponentData', function() {
             }
         }
         return ranges;
-    }, function(companies) {
-        var current_hash = _.pluck(companies, 'id').join('|');
-        return current_hash;
-    });
+    }, idListMemoFunction);
 
     this.ipoDateData = _.memoize(function(companies, extent) {
         var byMonth = {};
@@ -424,10 +416,7 @@ angular.module('crunchinatorApp.services').service('ComponentData', function() {
             });
             return o;
         }, []);
-    }, function(companies) {
-        var current_hash = _.pluck(companies, 'id').join('|');
-        return current_hash;
-    });
+    }, idListMemoFunction);
 
     /**
      * Abbreviates a number into a shortened string

--- a/app/views/main.tpl.html
+++ b/app/views/main.tpl.html
@@ -18,7 +18,7 @@
         <div>
             <div d3-map
                 chart-title="Company HQ"
-                data="ComponentData.companyStateData(companies.dataForLocationMap)"
+                data="ComponentData.dataSets.companyStateData"
                 selected="states"
             ></div>
         </div>
@@ -26,7 +26,7 @@
         <div>
              <div d3-area
                 chart-title="Investments"
-                data="ComponentData.fundingRoundCount(fundingRounds.dataForInvestments, '1/2000')"
+                data="ComponentData.dataSets.fundingRoundCount"
                 selected="fundingActivity"
                 extent="1/2000"
                 ranges="true"
@@ -45,7 +45,7 @@
         <div>
             <div d3-pie
                 chart-title="Company Status"
-                data="ComponentData.companyStatusData(companies.dataForCompanyStatus)"
+                data="ComponentData.dataSets.companyStatusData"
                 selected="statuses"
             ></div>
         </div>
@@ -62,7 +62,7 @@
         <div>
             <div d3-bars
                 chart-title="Funding: Total Funding"
-                data="ComponentData.totalFunding(companies.dataForTotalFunding, companies.maxCompanyValue)"
+                data="ComponentData.dataSets.totalFunding"
                 selected="ranges"
                 ranges="true"
             ></div>
@@ -71,7 +71,7 @@
         <div>
             <div d3-bars
                 chart-title="Funding: Any Round"
-                data="ComponentData.fundingPerRound(fundingRounds.dataForFundingAmount, fundingRounds.maxFundingValue)"
+                data="ComponentData.dataSets.fundingPerRound"
                 selected="roundRanges"
                 ranges="true"
             ></div>
@@ -80,7 +80,7 @@
         <div>
             <div d3-bars
                 chart-title="Funding: Latest Round"
-                data="ComponentData.mostRecentFundingRound(companies.dataForMostRecentRaisedAmount, companies.maxRecentFundingValue)"
+                data="ComponentData.dataSets.mostRecentFundingRound"
                 selected="mostRecentRoundRanges"
                 ranges="true"
             ></div>
@@ -89,7 +89,7 @@
         <div>
              <div d3-area
                 chart-title="Acquisition Date"
-                data="ComponentData.acquiredOnCount(companies.dataForAcquiredOnAreaChart, '1/2006')"
+                data="ComponentData.dataSets.acquiredOnCount"
                 selected="acquiredDate"
                 extent="1/2006"
                 ranges="true"
@@ -99,7 +99,7 @@
         <div>
             <div d3-bars
                 chart-title="Acquisition Price"
-                data="ComponentData.acquiredValueCount(companies.dataForAcquiredValue, companies.maxAcquiredValue)"
+                data="ComponentData.dataSets.acquiredValueCount"
                 selected="acquiredValueRange"
                 ranges="true"
             ></div>
@@ -108,7 +108,7 @@
         <div>
             <div list-select
                 chart-title="Funding: Round Name"
-                items="ComponentData.roundCodeListData(fundingRounds.dataForRoundName)"
+                items="ComponentData.dataSets.roundCodeListData"
                 selected="roundCodes"
                 total="fundingRounds.fundingSeries.length"
             ></div>
@@ -117,7 +117,7 @@
         <div>
              <div d3-area
                 chart-title="Founding Date"
-                data="ComponentData.foundedOnCount(companies.dataForFoundedOnAreaChart, '1992')"
+                data="ComponentData.dataSets.foundedOnCount"
                 selected="foundedDate"
                 extent="1992"
                 format="%Y"
@@ -128,7 +128,7 @@
         <div>
             <div d3-area
                 chart-title="IPO Date"
-                data="ComponentData.ipoDateData(companies.dataForIPODate, '1992')"
+                data="ComponentData.dataSets.ipoDateData"
                 selected="ipoDateRange"
                 extent="1992"
                 format="%Y"
@@ -139,7 +139,7 @@
         <div>
             <div d3-bars
                 chart-title="IPO Raise"
-                data="ComponentData.ipoValueData(companies.dataForIPOValue, companies.maxIPOValue)"
+                data="ComponentData.dataSets.ipoValueData"
                 selected="ipoValueRange"
                 ranges="true"
             ></div>


### PR DESCRIPTION
@hkal 

https://www.pivotaltracker.com/story/show/65764700
https://www.pivotaltracker.com/story/show/66696910

I refactored component data so that we only run it when a filter action happens, rather than on every angular digest. We had enough graphs that the memoize functions were taking long enough to make scrolling choppy. While I was in componentData I also abstracted the memoize functions that were doing the same thing. There's still a lot of improvements that we can do in componentData but I think this is a good step.
