### PR TITLE
allow users to use 'grunt serve:env:version' to start development server

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -457,7 +457,11 @@ module.exports = function (grunt) {
     });
 
 
-    grunt.registerTask('serve', function (target) {
+    grunt.registerTask('serve', function (target, version) {
+        if (version) {
+            ENV.version = version;
+        }
+
         target = target || 'development';
         if (target === 'dist') {
             return grunt.task.run(['build', 'connect:dist:keepalive']);


### PR DESCRIPTION
@nthomson - https://www.pivotaltracker.com/story/show/66631644
